### PR TITLE
Add guard check before attempting to complete _doneCompleter.

### DIFF
--- a/lib/src/channel_manager.dart
+++ b/lib/src/channel_manager.dart
@@ -53,7 +53,9 @@ class ChannelManager {
 
     _channel.stream.listen(handleInput,
         onError: (error, stackTrace) {
-          _doneCompleter.completeError(error, stackTrace);
+          if (!_doneCompleter.isCompleted) {
+            _doneCompleter.completeError(error, stackTrace);
+          }
           _channel.sink.close();
         },
         onDone: () {


### PR DESCRIPTION
This avoids the scenario where `close` is called, then an error is captured.