### PR TITLE
Fix strong mode errors, warnings, and hints.

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -173,7 +173,7 @@ class Client {
     if (response.containsKey("result")) {
       request.completer.complete(response["result"]);
     } else {
-      request.completer.completeError( new RpcException(
+      request.completer.completeError(new RpcException(
             response["error"]["code"],
             response["error"]["message"],
             data: response["error"]["data"]),

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -120,7 +120,10 @@ class Client {
           'parameters, was "$parameters".');
     }
 
-    var message = <String, dynamic>{"jsonrpc": "2.0", "method": method};
+    var message = <String, dynamic>{
+      "jsonrpc": "2.0",
+      "method": method
+    };
     if (id != null) message["id"] = id;
     if (parameters != null) message["params"] = parameters;
 
@@ -170,10 +173,10 @@ class Client {
     if (response.containsKey("result")) {
       request.completer.complete(response["result"]);
     } else {
-      request.completer.completeError(
-          new RpcException(
-              response["error"]["code"], response["error"]["message"],
-              data: response["error"]["data"]),
+      request.completer.completeError( new RpcException(
+            response["error"]["code"],
+            response["error"]["message"],
+            data: response["error"]["data"]),
           request.chain);
     }
   }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -50,7 +50,7 @@ class Client {
   /// [Client.listen] is called.
   Client(StreamChannel<String> channel)
       : this.withoutJson(channel
-            .transform(jsonDocument)
+            .transform(jsonDocument as StreamChannelTransformer<String, String>)
             .transformStream(ignoreFormatExceptions));
 
   /// Creates a [Client] that communicates using decoded messages over
@@ -121,10 +121,7 @@ class Client {
           'parameters, was "$parameters".');
     }
 
-    var message = <String, dynamic>{
-      "jsonrpc": "2.0",
-      "method": method
-    };
+    var message = <String, dynamic>{"jsonrpc": "2.0", "method": method};
     if (id != null) message["id"] = id;
     if (parameters != null) message["params"] = parameters;
 
@@ -174,10 +171,10 @@ class Client {
     if (response.containsKey("result")) {
       request.completer.complete(response["result"]);
     } else {
-      request.completer.completeError(new RpcException(
-            response["error"]["code"],
-            response["error"]["message"],
-            data: response["error"]["data"]),
+      request.completer.completeError(
+          new RpcException(
+              response["error"]["code"], response["error"]["message"],
+              data: response["error"]["data"]),
           request.chain);
     }
   }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -49,9 +49,8 @@ class Client {
   /// Note that the client won't begin listening to [responses] until
   /// [Client.listen] is called.
   Client(StreamChannel<String> channel)
-      : this.withoutJson(channel
-            .transform(jsonDocument)
-            .transformStream(ignoreFormatExceptions));
+      : this.withoutJson(
+            jsonDocument.bind(channel).transformStream(ignoreFormatExceptions));
 
   /// Creates a [Client] that communicates using decoded messages over
   /// [channel].

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -50,7 +50,7 @@ class Client {
   /// [Client.listen] is called.
   Client(StreamChannel<String> channel)
       : this.withoutJson(channel
-            .transform(jsonDocument as StreamChannelTransformer<String, String>)
+            .transform(jsonDocument)
             .transformStream(ignoreFormatExceptions));
 
   /// Creates a [Client] that communicates using decoded messages over

--- a/lib/src/peer.dart
+++ b/lib/src/peer.dart
@@ -44,9 +44,8 @@ class Peer implements Client, Server {
   /// Note that the peer won't begin listening to [channel] until [Peer.listen]
   /// is called.
   Peer(StreamChannel<String> channel)
-      : this.withoutJson(channel
-            .transform(jsonDocument)
-            .transform(respondToFormatExceptions));
+      : this.withoutJson(
+            jsonDocument.bind(channel).transform(respondToFormatExceptions));
 
   /// Creates a [Peer] that communicates using decoded messages over [channel].
   ///

--- a/lib/src/peer.dart
+++ b/lib/src/peer.dart
@@ -45,7 +45,7 @@ class Peer implements Client, Server {
   /// is called.
   Peer(StreamChannel<String> channel)
       : this.withoutJson(channel
-            .transform(jsonDocument)
+            .transform(jsonDocument as StreamChannelTransformer<String, String>)
             .transform(respondToFormatExceptions));
 
   /// Creates a [Peer] that communicates using decoded messages over [channel].
@@ -57,10 +57,10 @@ class Peer implements Client, Server {
   /// [Peer.listen] is called.
   Peer.withoutJson(StreamChannel channel)
       : _manager = new ChannelManager("Peer", channel) {
-    _server = new Server.withoutJson(new StreamChannel(
-        _serverIncomingForwarder.stream, channel.sink));
-    _client = new Client.withoutJson(new StreamChannel(
-        _clientIncomingForwarder.stream, channel.sink));
+    _server = new Server.withoutJson(
+        new StreamChannel(_serverIncomingForwarder.stream, channel.sink));
+    _client = new Client.withoutJson(
+        new StreamChannel(_clientIncomingForwarder.stream, channel.sink));
   }
 
   // Client methods.
@@ -93,8 +93,9 @@ class Peer implements Client, Server {
         } else {
           _serverIncomingForwarder.add(message);
         }
-      } else if (message is List && message.isNotEmpty &&
-                 message.first is Map) {
+      } else if (message is List &&
+          message.isNotEmpty &&
+          message.first is Map) {
         if (message.first.containsKey('result') ||
             message.first.containsKey('error')) {
           _clientIncomingForwarder.add(message);

--- a/lib/src/peer.dart
+++ b/lib/src/peer.dart
@@ -56,10 +56,10 @@ class Peer implements Client, Server {
   /// [Peer.listen] is called.
   Peer.withoutJson(StreamChannel channel)
       : _manager = new ChannelManager("Peer", channel) {
-    _server = new Server.withoutJson(
-        new StreamChannel(_serverIncomingForwarder.stream, channel.sink));
-    _client = new Client.withoutJson(
-        new StreamChannel(_clientIncomingForwarder.stream, channel.sink));
+    _server = new Server.withoutJson(new StreamChannel(
+        _serverIncomingForwarder.stream, channel.sink));
+    _client = new Client.withoutJson(new StreamChannel(
+        _clientIncomingForwarder.stream, channel.sink));
   }
 
   // Client methods.

--- a/lib/src/peer.dart
+++ b/lib/src/peer.dart
@@ -92,9 +92,8 @@ class Peer implements Client, Server {
         } else {
           _serverIncomingForwarder.add(message);
         }
-      } else if (message is List &&
-          message.isNotEmpty &&
-          message.first is Map) {
+      } else if (message is List && message.isNotEmpty &&
+                 message.first is Map) {
         if (message.first.containsKey('result') ||
             message.first.containsKey('error')) {
           _clientIncomingForwarder.add(message);

--- a/lib/src/peer.dart
+++ b/lib/src/peer.dart
@@ -45,7 +45,7 @@ class Peer implements Client, Server {
   /// is called.
   Peer(StreamChannel<String> channel)
       : this.withoutJson(channel
-            .transform(jsonDocument as StreamChannelTransformer<String, String>)
+            .transform(jsonDocument)
             .transform(respondToFormatExceptions));
 
   /// Creates a [Peer] that communicates using decoded messages over [channel].

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -181,19 +181,15 @@ class Server {
         } else {
           return null;
         }
-      } else {
-        if (request.containsKey('id')) {
-          final chain = new Chain.forTrace(stackTrace);
-          return new RpcException(
-              error_code.SERVER_ERROR, getErrorMessage(error),
-              data: {
-                'full': '$error',
-                'stack': '$chain',
-              }).serialize(request);
-        } else {
-          return null;
-        }
+      } else if (!request.containsKey('id')) {
+        return null;
       }
+      final chain = new Chain.forTrace(stackTrace);
+      return new RpcException(error_code.SERVER_ERROR, getErrorMessage(error),
+          data: {
+            'full': '$error',
+            'stack': '$chain',
+          }).serialize(request);
     }
   }
 

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -168,8 +168,12 @@ class Server {
       // response, even if one is generated on the server.
       if (!request.containsKey('id')) return null;
 
-      return {'jsonrpc': '2.0', 'result': result, 'id': request['id']};
-    } catch (error, stackTrace) {
+      return {
+        'jsonrpc': '2.0',
+        'result': result,
+        'id': request['id']
+      };
+    } catch (e, stackTrace) {
       if (error is RpcException) {
         if (error.code == error_code.INVALID_REQUEST ||
             request.containsKey('id')) {
@@ -196,54 +200,40 @@ class Server {
   /// Validates that [request] matches the JSON-RPC spec.
   void _validateRequest(request) {
     if (request is! Map) {
-      throw new RpcException(
-          error_code.INVALID_REQUEST,
-          'Request must be '
+      throw new RpcException(error_code.INVALID_REQUEST, 'Request must be '
           'an Array or an Object.');
     }
 
     if (!request.containsKey('jsonrpc')) {
-      throw new RpcException(
-          error_code.INVALID_REQUEST,
-          'Request must '
+      throw new RpcException(error_code.INVALID_REQUEST, 'Request must '
           'contain a "jsonrpc" key.');
     }
 
     if (request['jsonrpc'] != '2.0') {
-      throw new RpcException(
-          error_code.INVALID_REQUEST,
-          'Invalid JSON-RPC '
+      throw new RpcException(error_code.INVALID_REQUEST, 'Invalid JSON-RPC '
           'version ${JSON.encode(request['jsonrpc'])}, expected "2.0".');
     }
 
     if (!request.containsKey('method')) {
-      throw new RpcException(
-          error_code.INVALID_REQUEST,
-          'Request must '
+      throw new RpcException(error_code.INVALID_REQUEST, 'Request must '
           'contain a "method" key.');
     }
 
     var method = request['method'];
     if (request['method'] is! String) {
-      throw new RpcException(
-          error_code.INVALID_REQUEST,
-          'Request method must '
+      throw new RpcException(error_code.INVALID_REQUEST, 'Request method must '
           'be a string, but was ${JSON.encode(method)}.');
     }
 
     var params = request['params'];
     if (request.containsKey('params') && params is! List && params is! Map) {
-      throw new RpcException(
-          error_code.INVALID_REQUEST,
-          'Request params must '
+      throw new RpcException(error_code.INVALID_REQUEST, 'Request params must '
           'be an Array or an Object, but was ${JSON.encode(params)}.');
     }
 
     var id = request['id'];
     if (id != null && id is! String && id is! num) {
-      throw new RpcException(
-          error_code.INVALID_REQUEST,
-          'Request id must be a '
+      throw new RpcException(error_code.INVALID_REQUEST, 'Request id must be a '
           'string, number, or null, but was ${JSON.encode(id)}.');
     }
   }

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -173,20 +173,22 @@ class Server {
         'result': result,
         'id': request['id']
       };
-    } catch (error, stackTrace) {
+    } catch (e, stackTrace) {
+      var error = e;
+      if (error is! RpcException) {
+        error = new RpcException(
+            error_code.SERVER_ERROR, getErrorMessage(error), data: {
+          'full': error.toString(),
+          'stack': new Chain.forTrace(stackTrace).toString()
+        });
+      }
+
       if (error.code != error_code.INVALID_REQUEST &&
           !request.containsKey('id')) {
         return null;
+      } else {
+        return error.serialize(request);
       }
-
-      var e = error is RpcException
-          ? error
-          : new RpcException(error_code.SERVER_ERROR, getErrorMessage(error),
-              data: {
-                  'full': error.toString(),
-                  'stack': new Chain.forTrace(stackTrace).toString()
-                });
-      return e.serialize(request);
     }
   }
 

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -168,7 +168,11 @@ class Server {
       // response, even if one is generated on the server.
       if (!request.containsKey('id')) return null;
 
-      return {'jsonrpc': '2.0', 'result': result, 'id': request['id']};
+      return {
+        'jsonrpc': '2.0',
+        'result': result,
+        'id': request['id']
+      };
     } catch (e, stackTrace) {
       var error = e;
       if (error is! RpcException) {
@@ -191,54 +195,40 @@ class Server {
   /// Validates that [request] matches the JSON-RPC spec.
   void _validateRequest(request) {
     if (request is! Map) {
-      throw new RpcException(
-          error_code.INVALID_REQUEST,
-          'Request must be '
+      throw new RpcException(error_code.INVALID_REQUEST, 'Request must be '
           'an Array or an Object.');
     }
 
     if (!request.containsKey('jsonrpc')) {
-      throw new RpcException(
-          error_code.INVALID_REQUEST,
-          'Request must '
+      throw new RpcException(error_code.INVALID_REQUEST, 'Request must '
           'contain a "jsonrpc" key.');
     }
 
     if (request['jsonrpc'] != '2.0') {
-      throw new RpcException(
-          error_code.INVALID_REQUEST,
-          'Invalid JSON-RPC '
+      throw new RpcException(error_code.INVALID_REQUEST, 'Invalid JSON-RPC '
           'version ${JSON.encode(request['jsonrpc'])}, expected "2.0".');
     }
 
     if (!request.containsKey('method')) {
-      throw new RpcException(
-          error_code.INVALID_REQUEST,
-          'Request must '
+      throw new RpcException(error_code.INVALID_REQUEST, 'Request must '
           'contain a "method" key.');
     }
 
     var method = request['method'];
     if (request['method'] is! String) {
-      throw new RpcException(
-          error_code.INVALID_REQUEST,
-          'Request method must '
+      throw new RpcException(error_code.INVALID_REQUEST, 'Request method must '
           'be a string, but was ${JSON.encode(method)}.');
     }
 
     var params = request['params'];
     if (request.containsKey('params') && params is! List && params is! Map) {
-      throw new RpcException(
-          error_code.INVALID_REQUEST,
-          'Request params must '
+      throw new RpcException(error_code.INVALID_REQUEST, 'Request params must '
           'be an Array or an Object, but was ${JSON.encode(params)}.');
     }
 
     var id = request['id'];
     if (id != null && id is! String && id is! num) {
-      throw new RpcException(
-          error_code.INVALID_REQUEST,
-          'Request id must be a '
+      throw new RpcException(error_code.INVALID_REQUEST, 'Request id must be a '
           'string, number, or null, but was ${JSON.encode(id)}.');
     }
   }

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -57,7 +57,7 @@ class Server {
   /// [Server.listen] is called.
   Server(StreamChannel<String> channel)
       : this.withoutJson(channel
-            .transform(jsonDocument as StreamChannelTransformer<String, String>)
+            .transform(jsonDocument)
             .transform(respondToFormatExceptions));
 
   /// Creates a [Server] that communicates using decoded messages over

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -56,9 +56,8 @@ class Server {
   /// Note that the server won't begin listening to [requests] until
   /// [Server.listen] is called.
   Server(StreamChannel<String> channel)
-      : this.withoutJson(channel
-            .transform(jsonDocument)
-            .transform(respondToFormatExceptions));
+      : this.withoutJson(
+            jsonDocument.bind(channel).transform(respondToFormatExceptions));
 
   /// Creates a [Server] that communicates using decoded messages over
   /// [channel].

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -168,12 +168,8 @@ class Server {
       // response, even if one is generated on the server.
       if (!request.containsKey('id')) return null;
 
-      return {
-        'jsonrpc': '2.0',
-        'result': result,
-        'id': request['id']
-      };
-    } catch (e, stackTrace) {
+      return {'jsonrpc': '2.0', 'result': result, 'id': request['id']};
+    } catch (error, stackTrace) {
       if (error is RpcException) {
         if (error.code == error_code.INVALID_REQUEST ||
             request.containsKey('id')) {
@@ -200,40 +196,54 @@ class Server {
   /// Validates that [request] matches the JSON-RPC spec.
   void _validateRequest(request) {
     if (request is! Map) {
-      throw new RpcException(error_code.INVALID_REQUEST, 'Request must be '
+      throw new RpcException(
+          error_code.INVALID_REQUEST,
+          'Request must be '
           'an Array or an Object.');
     }
 
     if (!request.containsKey('jsonrpc')) {
-      throw new RpcException(error_code.INVALID_REQUEST, 'Request must '
+      throw new RpcException(
+          error_code.INVALID_REQUEST,
+          'Request must '
           'contain a "jsonrpc" key.');
     }
 
     if (request['jsonrpc'] != '2.0') {
-      throw new RpcException(error_code.INVALID_REQUEST, 'Invalid JSON-RPC '
+      throw new RpcException(
+          error_code.INVALID_REQUEST,
+          'Invalid JSON-RPC '
           'version ${JSON.encode(request['jsonrpc'])}, expected "2.0".');
     }
 
     if (!request.containsKey('method')) {
-      throw new RpcException(error_code.INVALID_REQUEST, 'Request must '
+      throw new RpcException(
+          error_code.INVALID_REQUEST,
+          'Request must '
           'contain a "method" key.');
     }
 
     var method = request['method'];
     if (request['method'] is! String) {
-      throw new RpcException(error_code.INVALID_REQUEST, 'Request method must '
+      throw new RpcException(
+          error_code.INVALID_REQUEST,
+          'Request method must '
           'be a string, but was ${JSON.encode(method)}.');
     }
 
     var params = request['params'];
     if (request.containsKey('params') && params is! List && params is! Map) {
-      throw new RpcException(error_code.INVALID_REQUEST, 'Request params must '
+      throw new RpcException(
+          error_code.INVALID_REQUEST,
+          'Request params must '
           'be an Array or an Object, but was ${JSON.encode(params)}.');
     }
 
     var id = request['id'];
     if (id != null && id is! String && id is! num) {
-      throw new RpcException(error_code.INVALID_REQUEST, 'Request id must be a '
+      throw new RpcException(
+          error_code.INVALID_REQUEST,
+          'Request id must be a '
           'string, number, or null, but was ${JSON.encode(id)}.');
     }
   }

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -173,7 +173,7 @@ class Server {
         'result': result,
         'id': request['id']
       };
-    } catch (e, stackTrace) {
+    } catch (error, stackTrace) {
       if (error is RpcException) {
         if (error.code == error_code.INVALID_REQUEST ||
             request.containsKey('id')) {

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -173,22 +173,20 @@ class Server {
         'result': result,
         'id': request['id']
       };
-    } catch (e, stackTrace) {
-      var error = e;
-      if (error is! RpcException) {
-        error = new RpcException(
-            error_code.SERVER_ERROR, getErrorMessage(error), data: {
-          'full': error.toString(),
-          'stack': new Chain.forTrace(stackTrace).toString()
-        });
-      }
-
+    } catch (error, stackTrace) {
       if (error.code != error_code.INVALID_REQUEST &&
           !request.containsKey('id')) {
         return null;
-      } else {
-        return error.serialize(request);
       }
+
+      var e = error is RpcException
+          ? error
+          : new RpcException(error_code.SERVER_ERROR, getErrorMessage(error),
+              data: {
+                  'full': error.toString(),
+                  'stack': new Chain.forTrace(stackTrace).toString()
+                });
+      return e.serialize(request);
     }
   }
 

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -159,7 +159,7 @@ class Server {
           throw new RpcException.invalidParams('No parameters are allowed for '
               'method "$name".');
         }
-        result = method();
+        result = await method();
       } else {
         result = await method(new Parameters(name, request['params']));
       }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -4,17 +4,12 @@
 
 import 'dart:async';
 
-import 'package:stack_trace/stack_trace.dart';
 import 'package:stream_channel/stream_channel.dart';
 
 import '../error_code.dart' as error_code;
 import 'exception.dart';
 
 typedef ZeroArgumentFunction();
-
-/// Like [new Future.sync], but automatically wraps the future in a
-/// [Chain.track] call.
-Future syncFuture(callback()) => Chain.track(new Future.sync(callback));
 
 /// Returns a sentence fragment listing the elements of [iter].
 ///
@@ -69,8 +64,9 @@ tryFinally(body(), whenComplete()) {
 }
 
 /// A transformer that silently drops [FormatException]s.
-final ignoreFormatExceptions = new StreamTransformer.fromHandlers(
-    handleError: (error, stackTrace, sink) {
+final ignoreFormatExceptions =
+    new StreamTransformer<Object, Object>.fromHandlers(
+        handleError: (error, stackTrace, sink) {
   if (error is FormatException) return;
   sink.addError(error, stackTrace);
 });

--- a/test/client/utils.dart
+++ b/test/client/utils.dart
@@ -5,9 +5,10 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:json_rpc_2/json_rpc_2.dart' as json_rpc;
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
+
+import 'package:json_rpc_2/json_rpc_2.dart' as json_rpc;
 
 /// A controller used to test a [json_rpc.Client].
 class ClientController {
@@ -34,15 +35,13 @@ class ClientController {
   /// null, no response is sent. Otherwise, the return value is encoded and sent
   /// as the response.
   void expectRequest(callback(request)) {
-    expect(
-        _requestController.stream.first.then((request) {
-          return callback(JSON.decode(request));
-        }).then((response) {
-          if (response == null) return;
-          if (response is! String) response = JSON.encode(response);
-          _responseController.add(response);
-        }),
-        completes);
+    expect(_requestController.stream.first.then((request) {
+      return callback(JSON.decode(request));
+    }).then((response) {
+      if (response == null) return;
+      if (response is! String) response = JSON.encode(response);
+      _responseController.add(response);
+    }), completes);
   }
 
   /// Sends [response], a decoded response, to [client].

--- a/test/client/utils.dart
+++ b/test/client/utils.dart
@@ -5,10 +5,9 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:json_rpc_2/json_rpc_2.dart' as json_rpc;
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
-
-import 'package:json_rpc_2/json_rpc_2.dart' as json_rpc;
 
 /// A controller used to test a [json_rpc.Client].
 class ClientController {
@@ -35,20 +34,26 @@ class ClientController {
   /// null, no response is sent. Otherwise, the return value is encoded and sent
   /// as the response.
   void expectRequest(callback(request)) {
-    expect(_requestController.stream.first.then((request) {
-      return callback(JSON.decode(request));
-    }).then((response) {
-      if (response == null) return;
-      if (response is! String) response = JSON.encode(response);
-      _responseController.add(response);
-    }), completes);
+    expect(
+        _requestController.stream.first.then((request) {
+          return callback(JSON.decode(request));
+        }).then((response) {
+          if (response == null) return;
+          if (response is! String) response = JSON.encode(response);
+          _responseController.add(response);
+        }),
+        completes);
   }
 
   /// Sends [response], a decoded response, to [client].
-  Future sendResponse(response) => sendJsonResponse(JSON.encode(response));
+  void sendResponse(response) {
+    sendJsonResponse(JSON.encode(response));
+  }
 
   /// Sends [response], a JSON-encoded response, to [client].
-  Future sendJsonResponse(String request) => _responseController.add(request);
+  void sendJsonResponse(String request) {
+    _responseController.add(request);
+  }
 }
 
 /// Returns a [Future] that completes after pumping the event queue [times]

--- a/test/peer_test.dart
+++ b/test/peer_test.dart
@@ -5,10 +5,11 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:json_rpc_2/error_code.dart' as error_code;
-import 'package:json_rpc_2/json_rpc_2.dart' as json_rpc;
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
+
+import 'package:json_rpc_2/error_code.dart' as error_code;
+import 'package:json_rpc_2/json_rpc_2.dart' as json_rpc;
 
 void main() {
   var incoming;
@@ -26,59 +27,71 @@ void main() {
   group("like a client,", () {
     test("can send a message and receive a response", () {
       expect(outgoing.first.then((request) {
-        expect(
-            request,
-            equals({
-              "jsonrpc": "2.0",
-              "method": "foo",
-              "params": {"bar": "baz"},
-              "id": 0
-            }));
-        incoming.add({"jsonrpc": "2.0", "result": "qux", "id": 0});
+        expect(request, equals({
+          "jsonrpc": "2.0",
+          "method": "foo",
+          "params": {"bar": "baz"},
+          "id": 0
+        }));
+        incoming.add({
+          "jsonrpc": "2.0",
+          "result": "qux",
+          "id": 0
+        });
       }), completes);
 
       peer.listen();
-      expect(
-          peer.sendRequest("foo", {"bar": "baz"}), completion(equals("qux")));
+      expect(peer.sendRequest("foo", {"bar": "baz"}),
+          completion(equals("qux")));
     });
 
     test("can send a batch of messages and receive a batch of responses", () {
       expect(outgoing.first.then((request) {
-        expect(
-            request,
-            equals([
-              {
-                "jsonrpc": "2.0",
-                "method": "foo",
-                "params": {"bar": "baz"},
-                "id": 0
-              },
-              {
-                "jsonrpc": "2.0",
-                "method": "a",
-                "params": {"b": "c"},
-                "id": 1
-              },
-              {
-                "jsonrpc": "2.0",
-                "method": "w",
-                "params": {"x": "y"},
-                "id": 2
-              }
-            ]));
+        expect(request, equals([
+          {
+            "jsonrpc": "2.0",
+            "method": "foo",
+            "params": {"bar": "baz"},
+            "id": 0
+          },
+          {
+            "jsonrpc": "2.0",
+            "method": "a",
+            "params": {"b": "c"},
+            "id": 1
+          },
+          {
+            "jsonrpc": "2.0",
+            "method": "w",
+            "params": {"x": "y"},
+            "id": 2
+          }
+        ]));
 
         incoming.add([
-          {"jsonrpc": "2.0", "result": "qux", "id": 0},
-          {"jsonrpc": "2.0", "result": "d", "id": 1},
-          {"jsonrpc": "2.0", "result": "z", "id": 2}
+          {
+            "jsonrpc": "2.0",
+            "result": "qux",
+            "id": 0
+          },
+          {
+            "jsonrpc": "2.0",
+            "result": "d",
+            "id": 1
+          },
+          {
+            "jsonrpc": "2.0",
+            "result": "z",
+            "id": 2
+          }
         ]);
       }), completes);
 
       peer.listen();
 
       peer.withBatch(() {
-        expect(
-            peer.sendRequest("foo", {"bar": "baz"}), completion(equals("qux")));
+        expect(peer.sendRequest("foo", {"bar": "baz"}),
+            completion(equals("qux")));
         expect(peer.sendRequest("a", {"b": "c"}), completion(equals("d")));
         expect(peer.sendRequest("w", {"x": "y"}), completion(equals("z")));
       });
@@ -87,8 +100,11 @@ void main() {
 
   group("like a server,", () {
     test("can receive a call and return a response", () {
-      expect(outgoing.first,
-          completion(equals({"jsonrpc": "2.0", "result": "qux", "id": 0})));
+      expect(outgoing.first, completion(equals({
+        "jsonrpc": "2.0",
+        "result": "qux",
+        "id": 0
+      })));
 
       peer.registerMethod("foo", (_) => "qux");
       peer.listen();
@@ -102,13 +118,23 @@ void main() {
     });
 
     test("can receive a batch of calls and return a batch of responses", () {
-      expect(
-          outgoing.first,
-          completion(equals([
-            {"jsonrpc": "2.0", "result": "qux", "id": 0},
-            {"jsonrpc": "2.0", "result": "d", "id": 1},
-            {"jsonrpc": "2.0", "result": "z", "id": 2}
-          ])));
+      expect(outgoing.first, completion(equals([
+        {
+          "jsonrpc": "2.0",
+          "result": "qux",
+          "id": 0
+        },
+        {
+          "jsonrpc": "2.0",
+          "result": "d",
+          "id": 1
+        },
+        {
+          "jsonrpc": "2.0",
+          "result": "z",
+          "id": 2
+        }
+      ])));
 
       peer.registerMethod("foo", (_) => "qux");
       peer.registerMethod("a", (_) => "d");
@@ -143,20 +169,16 @@ void main() {
       var jsonPeer = new json_rpc.Peer(
           new StreamChannel(incomingController.stream, outgoingController));
 
-      expect(
-          outgoingController.stream.first.then(JSON.decode),
-          completion({
-            "jsonrpc": "2.0",
-            "error": {
-              'code': error_code.PARSE_ERROR,
-              "message": startsWith("Invalid JSON: "),
-              // TODO(nweiz): Always expect the source when sdk#25655 is fixed.
-              "data": {
-                'request': anyOf([isNull, '{invalid'])
-              }
-            },
-            "id": null
-          }));
+      expect(outgoingController.stream.first.then(JSON.decode), completion({
+        "jsonrpc": "2.0",
+        "error": {
+          'code': error_code.PARSE_ERROR,
+          "message": startsWith("Invalid JSON: "),
+          // TODO(nweiz): Always expect the source when sdk#25655 is fixed.
+          "data": {'request': anyOf([isNull, '{invalid'])}
+        },
+        "id": null
+      }));
 
       jsonPeer.listen();
 
@@ -164,23 +186,21 @@ void main() {
     });
 
     test("returns a response for incorrectly-structured JSON", () {
-      expect(
-          outgoing.first,
-          completion({
-            "jsonrpc": "2.0",
-            "error": {
-              'code': error_code.INVALID_REQUEST,
-              "message": 'Request must contain a "jsonrpc" key.',
-              "data": {
-                'request': {'completely': 'wrong'}
-              }
-            },
-            "id": null
-          }));
+      expect(outgoing.first, completion({
+        "jsonrpc": "2.0",
+        "error": {
+          'code': error_code.INVALID_REQUEST,
+          "message": 'Request must contain a "jsonrpc" key.',
+          "data": {'request': {'completely': 'wrong'}}
+        },
+        "id": null
+      }));
 
       peer.listen();
 
-      incoming.add({"completely": "wrong"});
+      incoming.add({
+        "completely": "wrong"
+      });
     });
   });
 }


### PR DESCRIPTION
Part of https://github.com/dart-lang/json_rpc_2/issues/13.

*   ~~Added cast to `jsonDocument` in `StreamChannel<String>.transform(jsonDocument)`. `jsonDocument` is a `StreamChannelTransformer<Object, String>` which doesn't implicitly cast to the required `StreamChannelTransformer<String, dynamic>`.~~ (Removed because fix didn't work -- will investigate better fix).
*   Change `StreamChannel.transform(StreamChannelTransformer)` to `StreamChannelTransformer.bind(StreamChannel)` which, according to the docs, is identical but has better type handling. (Instead of above initial attempt at fixing use of `jsonDocument`).
*   Added types to `ignoreFormatExceptions` of `StreamTransformer<Object, Object>`.
*   Changed declared return type of `sendResponse` and `sendJsonResponse` to `void` to match code.
*   Removed `syncFuture` as it relies on a deprecated method and, since Dart 1.7, is just the same as `new Future.sync`.
*   Some dartfmt churn.