### PR TITLE
Add splitJsonTransformer to Server/Client/Peer Streams

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -49,8 +49,10 @@ class Client {
   /// Note that the client won't begin listening to [responses] until
   /// [Client.listen] is called.
   Client(StreamChannel<String> channel)
-      : this.withoutJson(
-            jsonDocument.bind(channel).transformStream(ignoreFormatExceptions));
+      : this.withoutJson(channel
+            .transform(splitJsonObjects)
+            .transform(jsonDocument)
+            .transform(respondToFormatExceptions));
 
   /// Creates a [Client] that communicates using decoded messages over
   /// [channel].

--- a/lib/src/peer.dart
+++ b/lib/src/peer.dart
@@ -44,8 +44,10 @@ class Peer implements Client, Server {
   /// Note that the peer won't begin listening to [channel] until [Peer.listen]
   /// is called.
   Peer(StreamChannel<String> channel)
-      : this.withoutJson(
-            jsonDocument.bind(channel).transform(respondToFormatExceptions));
+      : this.withoutJson(channel
+            .transform(splitJsonObjects)
+            .transform(jsonDocument)
+            .transform(respondToFormatExceptions));
 
   /// Creates a [Peer] that communicates using decoded messages over [channel].
   ///

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -56,8 +56,10 @@ class Server {
   /// Note that the server won't begin listening to [requests] until
   /// [Server.listen] is called.
   Server(StreamChannel<String> channel)
-      : this.withoutJson(
-            jsonDocument.bind(channel).transform(respondToFormatExceptions));
+      : this.withoutJson(channel
+            .transform(splitJsonObjects)
+            .transform(jsonDocument)
+            .transform(respondToFormatExceptions));
 
   /// Creates a [Server] that communicates using decoded messages over
   /// [channel].


### PR DESCRIPTION
Because jsonDocument (JsonDocumentTransformer) expects invididual JSON-encoded objects, splitJsonTransformer parses multiple JSON objects into separate Stream objects.