### PR TITLE
Add splitJsonTransformer to Server/Client/Peer Streams

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -49,8 +49,10 @@ class Client {
   /// Note that the client won't begin listening to [responses] until
   /// [Client.listen] is called.
   Client(StreamChannel<String> channel)
-      : this.withoutJson(
-            jsonDocument.bind(channel).transformStream(ignoreFormatExceptions));
+      : this.withoutJson(channel
+            .transform(splitJsonObjects)
+            .transform(jsonDocument)
+            .transform(respondToFormatExceptions));
 
   /// Creates a [Client] that communicates using decoded messages over
   /// [channel].

--- a/lib/src/peer.dart
+++ b/lib/src/peer.dart
@@ -44,8 +44,10 @@ class Peer implements Client, Server {
   /// Note that the peer won't begin listening to [channel] until [Peer.listen]
   /// is called.
   Peer(StreamChannel<String> channel)
-      : this.withoutJson(
-            jsonDocument.bind(channel).transform(respondToFormatExceptions));
+      : this.withoutJson(channel
+            .transform(splitJsonObjects)
+            .transform(jsonDocument)
+            .transform(respondToFormatExceptions));
 
   /// Creates a [Peer] that communicates using decoded messages over [channel].
   ///

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -56,8 +56,10 @@ class Server {
   /// Note that the server won't begin listening to [requests] until
   /// [Server.listen] is called.
   Server(StreamChannel<String> channel)
-      : this.withoutJson(
-            jsonDocument.bind(channel).transform(respondToFormatExceptions));
+      : this.withoutJson(channel
+            .transform(splitJsonObjects)
+            .transform(jsonDocument)
+            .transform(respondToFormatExceptions));
 
   /// Creates a [Server] that communicates using decoded messages over
   /// [channel].

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -94,13 +94,20 @@ class _RespondToFormatExceptionsTransformer
 }
 
 /// Splits a string of concatenated, encoded JSON objects into a List of
-/// encoded JSON objects
+/// encoded JSON objects. Also handles a single JSON object split over
+/// multiple packets.
+var cachedJson = '';
+var braceCount = 0;
+var inString = false;
 List<String> _splitJson(json) {
+  var startPos = cachedJson.length;
+  json = cachedJson + json;
+  cachedJson = '';
+
   final events = List<String>();
-  var braceCount = 0;
-  var inString = false;
-  var startPos = 0;
-  for (var i = 0; i < json.length; i++) {
+  var i = startPos;
+  startPos = 0;
+  for (; i < json.length; i++) {
     final c = json[i];
     if (c == '"') {
       inString = !inString;
@@ -115,6 +122,9 @@ List<String> _splitJson(json) {
       events.add(json.substring(startPos, (i + 1)));
       startPos = i + 1;
     }
+  }
+  if (braceCount > 0) {
+    cachedJson = json.substring(startPos);
   }
   return events;
 }


### PR DESCRIPTION
Because jsonDocument (JsonDocumentTransformer) expects invididual JSON-encoded objects, splitJsonTransformer parses multiple JSON objects into separate Stream objects.