### PR TITLE
Add an unhandledError callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.10
 
-* `Server` and related classes canq now take an `onUnhandledError` callback to
+* `Server` and related classes can now take an `onUnhandledError` callback to
   notify callers of unhandled exceptions.
 
 ## 2.0.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.10
+
+* `Server` and related classes canq now take an `onUnhandledError` callback to
+  notify callers of unhandled exceptions.
+
 ## 2.0.8
 
 * Updated SDK version to 2.0.0-dev.17.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.11
+## 2.1.0
 
 * `Server` and related classes can now take an `onUnhandledError` callback to
   notify callers of unhandled exceptions.

--- a/lib/src/peer.dart
+++ b/lib/src/peer.dart
@@ -39,13 +39,17 @@ class Peer implements Client, Server {
   Future get done => _manager.done;
   bool get isClosed => _manager.isClosed;
 
+  @override
+  ErrorCallback get onUnhandledError => _server?.onUnhandledError;
+
   /// Creates a [Peer] that communicates over [channel].
   ///
   /// Note that the peer won't begin listening to [channel] until [Peer.listen]
   /// is called.
-  Peer(StreamChannel<String> channel)
+  Peer(StreamChannel<String> channel, {ErrorCallback onUnhandledError})
       : this.withoutJson(
-            jsonDocument.bind(channel).transform(respondToFormatExceptions));
+            jsonDocument.bind(channel).transform(respondToFormatExceptions),
+            onUnhandledError: onUnhandledError);
 
   /// Creates a [Peer] that communicates using decoded messages over [channel].
   ///
@@ -54,10 +58,11 @@ class Peer implements Client, Server {
   ///
   /// Note that the peer won't begin listening to [channel] until
   /// [Peer.listen] is called.
-  Peer.withoutJson(StreamChannel channel)
+  Peer.withoutJson(StreamChannel channel, {ErrorCallback onUnhandledError})
       : _manager = new ChannelManager("Peer", channel) {
     _server = new Server.withoutJson(
-        new StreamChannel(_serverIncomingForwarder.stream, channel.sink));
+        new StreamChannel(_serverIncomingForwarder.stream, channel.sink),
+        onUnhandledError: onUnhandledError);
     _client = new Client.withoutJson(
         new StreamChannel(_clientIncomingForwarder.stream, channel.sink));
   }

--- a/lib/src/peer.dart
+++ b/lib/src/peer.dart
@@ -46,6 +46,9 @@ class Peer implements Client, Server {
   ///
   /// Note that the peer won't begin listening to [channel] until [Peer.listen]
   /// is called.
+  ///
+  /// Unhandled exceptions in callbacks will be forwarded to [onUnhandledError].
+  /// If this is not provided, unhandled exceptions will be swallowed.
   Peer(StreamChannel<String> channel, {ErrorCallback onUnhandledError})
       : this.withoutJson(
             jsonDocument.bind(channel).transform(respondToFormatExceptions),
@@ -58,6 +61,9 @@ class Peer implements Client, Server {
   ///
   /// Note that the peer won't begin listening to [channel] until
   /// [Peer.listen] is called.
+  ///
+  /// Unhandled exceptions in callbacks will be forwarded to [onUnhandledError].
+  /// If this is not provided, unhandled exceptions will be swallowed.
   Peer.withoutJson(StreamChannel channel, {ErrorCallback onUnhandledError})
       : _manager = new ChannelManager("Peer", channel) {
     _server = new Server.withoutJson(

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -54,12 +54,20 @@ class Server {
   /// endpoint closes the connection.
   bool get isClosed => _manager.isClosed;
 
+  /// A callback that is fired on unhandled exceptions.
+  ///
+  /// In the case where a user provided callback results in an exception that
+  /// cannot be properly routed back to the client, this handler will be
+  /// invoked. If it is not set, the exception will be swallowed.
   final ErrorCallback onUnhandledError;
 
   /// Creates a [Server] that communicates over [channel].
   ///
   /// Note that the server won't begin listening to [requests] until
   /// [Server.listen] is called.
+  ///
+  /// Unhandled exceptions in callbacks will be forwarded to [onUnhandledError].
+  /// If this is not provided, unhandled exceptions will be swallowed.
   Server(StreamChannel<String> channel, {ErrorCallback onUnhandledError})
       : this.withoutJson(
             jsonDocument.bind(channel).transform(respondToFormatExceptions),
@@ -73,6 +81,9 @@ class Server {
   ///
   /// Note that the server won't begin listening to [requests] until
   /// [Server.listen] is called.
+  ///
+  /// Unhandled exceptions in callbacks will be forwarded to [onUnhandledError].
+  /// If this is not provided, unhandled exceptions will be swallowed.
   Server.withoutJson(StreamChannel channel, {this.onUnhandledError})
       : _manager = new ChannelManager("Server", channel);
 

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -175,10 +175,10 @@ class Server {
             request.containsKey('id')) {
           return error.serialize(request);
         } else {
-          return null;
+          rethrow;
         }
       } else if (!request.containsKey('id')) {
-        return null;
+        rethrow;
       }
       final chain = new Chain.forTrace(stackTrace);
       return new RpcException(error_code.SERVER_ERROR, getErrorMessage(error),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_rpc_2
-version: 2.0.11
+version: 2.1.0
 author: Dart Team <misc@dartlang.org>
 description: >-
   Utilities to write a client or server using the JSON-RPC 2.0 spec.

--- a/test/peer_test.dart
+++ b/test/peer_test.dart
@@ -191,10 +191,11 @@ void main() {
     var outgoingController = new StreamController();
     final Completer<Exception> completer = Completer<Exception>();
     peer = new json_rpc.Peer.withoutJson(
-        new StreamChannel(incomingController.stream, outgoingController),
-        onUnhandledError: (error, stack) {
-      completer.complete(error);
-    });
+      new StreamChannel(incomingController.stream, outgoingController),
+      onUnhandledError: (error, stack) {
+        completer.complete(error);
+      },
+    );
     peer
       ..registerMethod('foo', () => throw exception)
       ..listen();

--- a/test/peer_test.dart
+++ b/test/peer_test.dart
@@ -186,22 +186,21 @@ void main() {
   });
 
   test("can notify on unhandled errors for if the method throws", () async {
+    Exception exception = Exception('test exception');
     var incomingController = new StreamController();
     var outgoingController = new StreamController();
-    final Completer<bool> completer = Completer<bool>();
+    final Completer<Exception> completer = Completer<Exception>();
     peer = new json_rpc.Peer.withoutJson(
         new StreamChannel(incomingController.stream, outgoingController),
         onUnhandledError: (error, stack) {
-      completer.complete(true);
+      completer.complete(error);
     });
     peer
-      ..registerMethod('foo', () {
-        throw Exception();
-      })
+      ..registerMethod('foo', () => throw exception)
       ..listen();
 
     incomingController.add({'jsonrpc': '2.0', 'method': 'foo'});
-    bool gotError = await completer.future;
-    expect(gotError, true);
+    Exception receivedException = await completer.future;
+    expect(receivedException, equals(exception));
   });
 }

--- a/test/server/utils.dart
+++ b/test/server/utils.dart
@@ -23,9 +23,10 @@ class ServerController {
   json_rpc.Server get server => _server;
   json_rpc.Server _server;
 
-  ServerController() {
+  ServerController({json_rpc.ErrorCallback onUnhandledError}) {
     _server = new json_rpc.Server(
-        new StreamChannel(_requestController.stream, _responseController.sink));
+        new StreamChannel(_requestController.stream, _responseController.sink),
+        onUnhandledError: onUnhandledError);
     _server.listen();
   }
 


### PR DESCRIPTION
A published version with this would help  flutter/flutter#28531

We ran into this scenario when a cast (that I believe worked in an earlier Dart version) no longer was acceptable.

/cc @kevmoo @liyuqian 