### PR TITLE
Allow stream_channel version 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.9
+
+* Allow `stream_channel` version 2.x
+
 ## 2.0.8
 
 * Updated SDK version to 2.0.0-dev.17.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,8 @@
 name: json_rpc_2
 version: 2.0.9
 author: Dart Team <misc@dartlang.org>
-description: An implementation of the JSON-RPC 2.0 spec.
+description: >-
+  Utilities to write a client or server using the JSON-RPC 2.0 spec.
 homepage: https://github.com/dart-lang/json_rpc_2
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,14 +2,14 @@ name: json_rpc_2
 version: 2.0.9
 author: Dart Team <misc@dartlang.org>
 description: An implementation of the JSON-RPC 2.0 spec.
-homepage: http://github.com/dart-lang/json_rpc_2
+homepage: https://github.com/dart-lang/json_rpc_2
 
 environment:
-  sdk: ">=2.0.0-dev.17.0 <3.0.0"
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
-  stack_trace: '>=0.9.1 <2.0.0'
-  stream_channel: '^1.1.0'
+  stack_trace: ^1.0.0
+  stream_channel: ">=1.1.0 <3.0.0"
 
 dev_dependencies:
   test: ^1.0.0


### PR DESCRIPTION
None of the planned breaking changes impact this package.

- Fix constraint style.
- Remove lower bound on `stack_trace` since versions before `1.0.0`
  didn't support the Dart 2 SDK anyway.