### PR TITLE
Bump to 2.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.9
+## 2.0.10
 
 * Allow `stream_channel` version 2.x
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_rpc_2
-version: 2.0.9
+version: 2.0.10
 author: Dart Team <misc@dartlang.org>
 description: >-
   Utilities to write a client or server using the JSON-RPC 2.0 spec.


### PR DESCRIPTION
Version 2.0.9 was already published with no changelog.