### PR TITLE
Update example

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,14 @@ Future main() async {
 
   // This calls the "count" method on the server. A Future is returned that
   // will complete to the value contained in the server's response.
-  await client.sendRequest('count')
+  await client
+      .sendRequest('count')
       .then((result) => print('Count is $result.'));
 
   // Parameters are passed as a simple Map or, for positional parameters, an
   // Iterable. Make sure they're JSON-serializable!
-  await client.sendRequest('echo', {'message': 'hello'})
-      .then((echo) => print('Echo says "$echo"!'));
+  await client.sendRequest(
+      'echo', {'message': 'hello'}).then((echo) => print('Echo says "$echo"!'));
 
   // A notification is a way to call a method that tells the server that no
   // result is expected. Its return type is `void`; even if it causes an
@@ -122,8 +123,8 @@ Future main() async {
   // If the server sends an error response, the returned Future will complete
   // with an RpcException. You can catch this error and inspect its error
   // code, message, and any data that the server sent along with it.
-  await client.sendRequest('divide', {'dividend': 2, 'divisor': 0})
-      .catchError((error) => print('RPC error ${error.code}: ${error.message}'));
+  await client.sendRequest('divide', {'dividend': 2, 'divisor': 0}).catchError(
+      (error) => print('RPC error ${error.code}: ${error.message}'));
 }
 ```
 

--- a/example/client.dart
+++ b/example/client.dart
@@ -1,0 +1,36 @@
+import 'dart:async';
+
+import 'package:json_rpc_2/json_rpc_2.dart' as json_rpc;
+import 'package:pedantic/pedantic.dart';
+import 'package:web_socket_channel/io.dart';
+
+Future main() async {
+  final channel = IOWebSocketChannel.connect('ws://localhost:4321');
+  final client = json_rpc.Client(channel.cast<String>());
+
+  // The client won't subscribe to the input stream until you call `listen`.
+  unawaited(
+    client.listen(),
+  );
+
+  // This calls the "count" method on the server. A Future is returned that
+  // will complete to the value contained in the server's response.
+  await client.sendRequest('count')
+      .then((result) => print('Count is $result.'));
+
+  // Parameters are passed as a simple Map or, for positional parameters, an
+  // Iterable. Make sure they're JSON-serializable!
+  await client.sendRequest('echo', {'message': 'hello'})
+      .then((echo) => print('Echo says "$echo"!'));
+
+  // A notification is a way to call a method that tells the server that no
+  // result is expected. Its return type is `void`; even if it causes an
+  // error, you won't hear back.
+  client.sendNotification('count');
+
+  // If the server sends an error response, the returned Future will complete
+  // with an RpcException. You can catch this error and inspect its error
+  // code, message, and any data that the server sent along with it.
+  await client.sendRequest('divide', {'dividend': 2, 'divisor': 0})
+      .catchError((error) => print('RPC error ${error.code}: ${error.message}'));
+}

--- a/example/client.dart
+++ b/example/client.dart
@@ -15,13 +15,14 @@ Future main() async {
 
   // This calls the "count" method on the server. A Future is returned that
   // will complete to the value contained in the server's response.
-  await client.sendRequest('count')
+  await client
+      .sendRequest('count')
       .then((result) => print('Count is $result.'));
 
   // Parameters are passed as a simple Map or, for positional parameters, an
   // Iterable. Make sure they're JSON-serializable!
-  await client.sendRequest('echo', {'message': 'hello'})
-      .then((echo) => print('Echo says "$echo"!'));
+  await client.sendRequest(
+      'echo', {'message': 'hello'}).then((echo) => print('Echo says "$echo"!'));
 
   // A notification is a way to call a method that tells the server that no
   // result is expected. Its return type is `void`; even if it causes an
@@ -31,6 +32,6 @@ Future main() async {
   // If the server sends an error response, the returned Future will complete
   // with an RpcException. You can catch this error and inspect its error
   // code, message, and any data that the server sent along with it.
-  await client.sendRequest('divide', {'dividend': 2, 'divisor': 0})
-      .catchError((error) => print('RPC error ${error.code}: ${error.message}'));
+  await client.sendRequest('divide', {'dividend': 2, 'divisor': 0}).catchError(
+      (error) => print('RPC error ${error.code}: ${error.message}'));
 }

--- a/example/server.dart
+++ b/example/server.dart
@@ -1,13 +1,3 @@
-A library that implements the [JSON-RPC 2.0 spec][spec].
-
-[spec]: http://www.jsonrpc.org/specification
-
-## Server
-
-A JSON-RPC 2.0 server exposes a set of methods that can be called by clients.
-These methods can be registered using `Server.registerMethod`:
-
-```dart
 import 'dart:async';
 import 'dart:io';
 
@@ -15,8 +5,8 @@ import 'package:json_rpc_2/json_rpc_2.dart' as json_rpc;
 import 'package:web_socket_channel/io.dart';
 
 Future<void> main() async {
-  final server = await HttpServer.bind('localhost', 4321);
-  server.listen((HttpRequest request) async {
+  final httpServer = await HttpServer.bind('localhost', 4321);
+  httpServer.listen((HttpRequest request) async {
     final socket = await WebSocketTransformer.upgrade(request);
     final channel = IOWebSocketChannel(socket);
 
@@ -80,58 +70,3 @@ Future<void> main() async {
     await server.listen();
   });
 }
-```
-
-## Client
-
-A JSON-RPC 2.0 client calls methods on a server and handles the server's
-responses to those method calls. These methods can be called using
-`Client.sendRequest`:
-
-```dart
-import 'dart:async';
-
-import 'package:json_rpc_2/json_rpc_2.dart' as json_rpc;
-import 'package:pedantic/pedantic.dart';
-import 'package:web_socket_channel/io.dart';
-
-Future main() async {
-  final channel = IOWebSocketChannel.connect('ws://localhost:4321');
-  final client = json_rpc.Client(channel.cast<String>());
-
-  // The client won't subscribe to the input stream until you call `listen`.
-  unawaited(
-    client.listen(),
-  );
-
-  // This calls the "count" method on the server. A Future is returned that
-  // will complete to the value contained in the server's response.
-  await client.sendRequest('count')
-      .then((result) => print('Count is $result.'));
-
-  // Parameters are passed as a simple Map or, for positional parameters, an
-  // Iterable. Make sure they're JSON-serializable!
-  await client.sendRequest('echo', {'message': 'hello'})
-      .then((echo) => print('Echo says "$echo"!'));
-
-  // A notification is a way to call a method that tells the server that no
-  // result is expected. Its return type is `void`; even if it causes an
-  // error, you won't hear back.
-  client.sendNotification('count');
-
-  // If the server sends an error response, the returned Future will complete
-  // with an RpcException. You can catch this error and inspect its error
-  // code, message, and any data that the server sent along with it.
-  await client.sendRequest('divide', {'dividend': 2, 'divisor': 0})
-      .catchError((error) => print('RPC error ${error.code}: ${error.message}'));
-}
-```
-
-## Peer
-
-Although JSON-RPC 2.0 only explicitly describes clients and servers, it also
-mentions that two-way communication can be supported by making each endpoint
-both a client and a server. This package supports this directly using the `Peer`
-class, which implements both `Client` and `Server`. It supports the same methods
-as those classes, and automatically makes sure that every message from the other
-endpoint is routed and handled correctly.


### PR DESCRIPTION
The example on README did not work. I've made changes to get it to work and confirmed it on Dart v2.0 and v2.7.

I'm wondering if my modification is correct because there were some strange inconsistencies as below that I have not understood quite well. I'm also not sure about my addition of `await`s and related relocation of `listen()`. It was necessary to avoid warnings. I'd be grateful if those parts would be reviewed carefully.

Inconsistencies:
- [This comment](12#issuecomment-254312151) has mentioned `IOWebSocketChannel.connect() is a client connection method`, but the client method was used in the server example.
- The server code says, `JSON RPC 2 only works with Strings so we assert it only emits those by casting it`, but the type casting was missing in the client code.
- `HtmlWebSocketChannel` was used on the client side, which I think should be `IOWebSocketChannel` unless it is a web example.