### PR TITLE
Fixed issue where throwing from within an asynchronous handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Fixed issue where throwing `RpcException.methodNotFound` in an asynchronous
+  fallback handler would not result in the next fallback being executed.
+
 ## 2.1.0
 
 * `Server` and related classes can now take an `onUnhandledError` callback to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 2.1.1
 
 * Fixed issue where throwing `RpcException.methodNotFound` in an asynchronous
   fallback handler would not result in the next fallback being executed.

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -273,7 +273,7 @@ class Server {
       }
 
       try {
-        return iterator.current(params);
+        return await iterator.current(params);
       } on RpcException catch (error) {
         if (error is! RpcException) rethrow;
         if (error.code != error_code.METHOD_NOT_FOUND) rethrow;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_rpc_2
-version: 2.1.0
+version: 2.1.1
 author: Dart Team <misc@dartlang.org>
 description: >-
   Utilities to write a client or server using the JSON-RPC 2.0 spec.


### PR DESCRIPTION
Fixed issue where throwing `RpcException.methodNotFound` from within an asynchronous fallback handler would not result in the next fallback handler being executed.