### PR TITLE
Fix `Peer` requests not terminating when the channel closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.1
+
+* Fix `Peer` requests not terminating when the underlying channel is closed.
+
 ## 2.2.0
 
 * Added `strictProtocolChecks` named parameter to `Server` and `Peer`

--- a/lib/src/peer.dart
+++ b/lib/src/peer.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:pedantic/pedantic.dart';
 import 'package:stream_channel/stream_channel.dart';
 
 import 'channel_manager.dart';
@@ -118,10 +119,10 @@ class Peer implements Client, Server {
   // Shared methods.
 
   @override
-  Future listen() {
-    _client.listen();
-    _server.listen();
-    return _manager.listen((message) {
+  Future listen() async {
+    unawaited(_client.listen());
+    unawaited(_server.listen());
+    await _manager.listen((message) {
       if (message is Map) {
         if (message.containsKey('result') || message.containsKey('error')) {
           _clientIncomingForwarder.add(message);
@@ -143,6 +144,8 @@ class Peer implements Client, Server {
         _serverIncomingForwarder.add(message);
       }
     });
+
+    return close();
   }
 
   @override

--- a/lib/src/peer.dart
+++ b/lib/src/peer.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:pedantic/pedantic.dart';
 import 'package:stream_channel/stream_channel.dart';
 
 import 'channel_manager.dart';
@@ -119,10 +118,10 @@ class Peer implements Client, Server {
   // Shared methods.
 
   @override
-  Future listen() async {
-    unawaited(_client.listen());
-    unawaited(_server.listen());
-    await _manager.listen((message) {
+  Future listen() {
+    _client.listen();
+    _server.listen();
+    return _manager.listen((message) {
       if (message is Map) {
         if (message.containsKey('result') || message.containsKey('error')) {
           _clientIncomingForwarder.add(message);
@@ -143,9 +142,7 @@ class Peer implements Client, Server {
         // server since it knows how to send error responses.
         _serverIncomingForwarder.add(message);
       }
-    });
-
-    return close();
+    }).whenComplete(close);
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
   sdk: ">=2.2.0 <3.0.0"
 
 dependencies:
+  pedantic: ^1.8.0
   stack_trace: ^1.0.0
   stream_channel: ">=1.1.0 <3.0.0"
 
 dev_dependencies:
-  pedantic: ^1.8.0
   test: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,10 +8,10 @@ environment:
   sdk: ">=2.2.0 <3.0.0"
 
 dependencies:
-  pedantic: ^1.8.0
   stack_trace: ^1.0.0
   stream_channel: ">=1.1.0 <3.0.0"
 
 dev_dependencies:
+  pedantic: ^1.8.0
   test: ^1.0.0
   web_socket_channel: ^1.1.0


### PR DESCRIPTION
The `listen()` method of `Peer` never propagates close events from its manager to the `client` field. This causes in-flight requests to never terminate as the clean up handler here is never called.

https://github.com/dart-lang/json_rpc_2/blob/d589e635d8ccb7cda6a804bd571f88abbabab146/lib/src/client.dart#L65-L72