### PR TITLE
Give a type to the _batch list

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -24,8 +24,8 @@ class Client {
 
   /// The current batch of requests to be sent together.
   ///
-  /// Each element is a JSON-serializable object.
-  List _batch;
+  /// Each element is a JSON RPC spec compliant message.
+  List<Map<String, dynamic>> _batch;
 
   /// The map of request ids to pending requests.
   final _pendingRequests = <int, _Request>{};


### PR DESCRIPTION
The comment and lack of type signal that this would be a list of objects
matching the `parameters` argument to `sendRequest`, but what is added
to this map is the full request which is always a `Map`.