### PR TITLE
Remove unnecessary StackTrace instantiation

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -64,10 +64,8 @@ class Client {
   Client.withoutJson(this._channel) {
     done.whenComplete(() {
       for (var request in _pendingRequests.values) {
-        request.completer.completeError(
-            StateError(
-                'The client closed with pending request "${request.method}".'),
-            StackTrace.current);
+        request.completer.completeError(StateError(
+            'The client closed with pending request "${request.method}".'));
       }
       _pendingRequests.clear();
     }).catchError((_) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_rpc_2
-version: 2.2.2
+version: 2.2.3-dev
 description: >-
   Utilities to write a client or server using the JSON-RPC 2.0 spec.
 homepage: https://github.com/dart-lang/json_rpc_2


### PR DESCRIPTION
Manually instantiating `StackTrace.current` when completing with an
error does not create a meaningfully different stack trace compared to
not passing one at all - it has an extra frame but not a meaningful one.