### PR TITLE
Prepare to publish with null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.0.0-dev
+## 3.0.0
 
 * Migrate to null safety.
 * Accept responses even if the server converts the ID to a String.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_rpc_2
-version: 3.0.0-dev
+version: 3.0.0
 description: >-
   Utilities to write a client or server using the JSON-RPC 2.0 spec.
 homepage: https://github.com/dart-lang/json_rpc_2
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   stack_trace: ^1.10.0
-  stream_channel: ">=1.1.0 <3.0.0"
+  stream_channel: ^2.1.0
 
 dev_dependencies:
   pedantic: ^1.11.0


### PR DESCRIPTION
Bump the `stream_channel` constraint so the lower bound is migrated for
null safety.