### PR TITLE
Allow a `null` result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.1-dev
+
+* Fix a bug where a `null` result to a request caused an exception.
+
 ## 3.0.0
 
 * Migrate to null safety.

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -201,7 +201,7 @@ class Server {
       var method = _methods[name];
       method ??= _tryFallbacks;
 
-      Object result;
+      Object? result;
       if (method is ZeroArgumentFunction) {
         if (request.containsKey('params')) {
           throw RpcException.invalidParams('No parameters are allowed for '

--- a/test/server/server_test.dart
+++ b/test/server/server_test.dart
@@ -44,6 +44,15 @@ void main() {
         completion(equals({'jsonrpc': '2.0', 'result': 'foo', 'id': 1234})));
   });
 
+  test('Allows a `null` result', () {
+    controller.server.registerMethod('foo', () => null);
+
+    expect(
+        controller
+            .handleRequest({'jsonrpc': '2.0', 'method': 'foo', 'id': 1234}),
+        completion(equals({'jsonrpc': '2.0', 'result': null, 'id': 1234})));
+  });
+
   test('a method that takes no parameters rejects parameters', () {
     controller.server.registerMethod('foo', () => 'foo');
 


### PR DESCRIPTION
Fixes #76

Add missing nullable annotation on the `result` variable and a test
which fails if the variable is non-nullable.