### PR TITLE
prep for publishing 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 3.0.2-dev
+## 3.0.2
 
+* Switch to using `package:lints`.
 * Address a few analysis hint violations.
 * Populate the pubspec `repository` field.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Dart CI](https://github.com/dart-lang/json_rpc_2/actions/workflows/test-package.yml/badge.svg)](https://github.com/dart-lang/json_rpc_2/actions/workflows/test-package.yml)
+[![pub package](https://img.shields.io/pub/v/json_rpc_2.svg)](https://pub.dev/packages/json_rpc_2)
+[![package publisher](https://img.shields.io/pub/publisher/json_rpc_2.svg)](https://pub.dev/packages/json_rpc_2/publisher)
+
 A library that implements the [JSON-RPC 2.0 spec][spec].
 
 [spec]: https://www.jsonrpc.org/specification

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,1 @@
-# Defines a default set of lint rules enforced for
-# projects at Google. For details and rationale,
-# see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
-
+include: package:lints/recommended.yaml

--- a/example/client.dart
+++ b/example/client.dart
@@ -2,8 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:json_rpc_2/json_rpc_2.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 void main() async {

--- a/lib/error_code.dart
+++ b/lib/error_code.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: constant_identifier_names
+
 /// Error codes defined in the [JSON-RPC 2.0 specificiation][spec].
 ///
 /// These codes are generally used for protocol-level communication. Most of

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -173,7 +173,10 @@ class Client {
   /// invokes [callback] without creating another batch. This means that
   /// responses are batched until the first batch ends.
   void withBatch(Function() callback) {
-    if (_batch != null) return callback();
+    if (_batch != null) {
+      callback();
+      return;
+    }
 
     _batch = [];
     return tryFinally(callback, () {

--- a/lib/src/exception.dart
+++ b/lib/src/exception.dart
@@ -24,7 +24,7 @@ class RpcException implements Exception {
   /// This must be a JSON-serializable object. If it's a [Map] without a
   /// `"request"` key, a copy of the request that caused the error will
   /// automatically be injected.
-  final data;
+  final Object? data;
 
   RpcException(this.code, this.message, {this.data});
 
@@ -44,9 +44,9 @@ class RpcException implements Exception {
   /// Converts this exception into a JSON-serializable object that's a valid
   /// JSON-RPC 2.0 error response.
   Map<String, dynamic> serialize(request) {
-    var modifiedData;
-    if (data is Map && !data.containsKey('request')) {
-      modifiedData = Map.from(data);
+    dynamic modifiedData;
+    if (data is Map && !(data as Map).containsKey('request')) {
+      modifiedData = Map.from(data as Map);
       modifiedData['request'] = request;
     } else if (data == null) {
       modifiedData = {'request': request};

--- a/lib/src/parameters.dart
+++ b/lib/src/parameters.dart
@@ -27,7 +27,7 @@ class Parameters {
   /// If this is accessed for a [Parameter] that was not passed, the request
   /// will be automatically rejected. To avoid this, use [Parameter.valueOr].
   dynamic get value => _value;
-  final _value;
+  final dynamic _value;
 
   Parameters(this.method, this._value);
 
@@ -111,7 +111,7 @@ class Parameter extends Parameters {
   final Parameters _parent;
 
   /// The key used to access [this], used to construct [_path].
-  final _key;
+  final dynamic _key;
 
   /// A human-readable representation of the path of getters used to get this.
   ///

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -172,7 +172,7 @@ class Server {
   /// if no response should be sent. [callback] may send custom
   /// errors by throwing an [RpcException].
   Future _handleRequest(request) async {
-    var response;
+    dynamic response;
     if (request is List) {
       if (request.isEmpty) {
         response = RpcException(error_code.INVALID_REQUEST,

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -28,7 +28,7 @@ String getErrorMessage(error) =>
 /// This is synchronicity-agnostic relative to [body]. If [body] returns a
 /// [Future], this wil run asynchronously; otherwise it will run synchronously.
 void tryFinally(Function() body, Function() whenComplete) {
-  var result;
+  dynamic result;
   try {
     result = body();
   } catch (_) {
@@ -38,7 +38,6 @@ void tryFinally(Function() body, Function() whenComplete) {
 
   if (result is! Future) {
     whenComplete();
-    return result;
   } else {
     result.whenComplete(whenComplete);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_rpc_2
-version: 3.0.2-dev
+version: 3.0.2
 description: >-
   Utilities to write a client or server using the JSON-RPC 2.0 spec.
 repository: https://github.com/dart-lang/json_rpc_2
@@ -12,6 +12,6 @@ dependencies:
   stream_channel: ^2.1.0
 
 dev_dependencies:
-  pedantic: ^1.11.0
+  lints: ^1.0.0
   test: ^1.16.0
   web_socket_channel: ^2.0.0

--- a/test/client/client_test.dart
+++ b/test/client/client_test.dart
@@ -9,7 +9,8 @@ import 'package:json_rpc_2/json_rpc_2.dart' as json_rpc;
 import 'utils.dart';
 
 void main() {
-  var controller;
+  late ClientController controller;
+
   setUp(() => controller = ClientController());
 
   test('sends a message and returns the response', () {

--- a/test/client/stream_test.dart
+++ b/test/client/stream_test.dart
@@ -10,9 +10,10 @@ import 'package:test/test.dart';
 import 'package:json_rpc_2/json_rpc_2.dart' as json_rpc;
 
 void main() {
-  var responseController;
-  var requestController;
-  var client;
+  late StreamController responseController;
+  late StreamController requestController;
+  late json_rpc.Client client;
+
   setUp(() {
     responseController = StreamController();
     requestController = StreamController();

--- a/test/peer_test.dart
+++ b/test/peer_test.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:pedantic/pedantic.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 
@@ -13,9 +12,10 @@ import 'package:json_rpc_2/error_code.dart' as error_code;
 import 'package:json_rpc_2/json_rpc_2.dart' as json_rpc;
 
 void main() {
-  var incoming;
-  var outgoing;
-  var peer;
+  late StreamSink incoming;
+  late Stream outgoing;
+  late json_rpc.Peer peer;
+
   setUp(() {
     var incomingController = StreamController();
     incoming = incomingController.sink;

--- a/test/server/batch_test.dart
+++ b/test/server/batch_test.dart
@@ -8,7 +8,8 @@ import 'package:json_rpc_2/error_code.dart' as error_code;
 import 'utils.dart';
 
 void main() {
-  var controller;
+  late ServerController controller;
+
   setUp(() {
     controller = ServerController();
     controller.server

--- a/test/server/invalid_request_test.dart
+++ b/test/server/invalid_request_test.dart
@@ -8,7 +8,7 @@ import 'package:json_rpc_2/error_code.dart' as error_code;
 import 'utils.dart';
 
 void main() {
-  var controller;
+  late ServerController controller;
   setUp(() => controller = ServerController());
 
   test('a non-Array/Object request is invalid', () {

--- a/test/server/parameters_test.dart
+++ b/test/server/parameters_test.dart
@@ -9,7 +9,7 @@ import 'utils.dart';
 
 void main() {
   group('with named parameters', () {
-    var parameters;
+    late json_rpc.Parameters parameters;
     setUp(() {
       parameters = json_rpc.Parameters('foo', {
         'num': 1.5,
@@ -277,7 +277,7 @@ void main() {
     });
 
     group('with a nested parameter map', () {
-      var nested;
+      late json_rpc.Parameter nested;
       setUp(() => nested = parameters['map']);
 
       test('[int] fails with a type error', () {
@@ -312,7 +312,8 @@ void main() {
     });
 
     group('with a nested parameter list', () {
-      var nested;
+      late json_rpc.Parameter nested;
+
       setUp(() => nested = parameters['list']);
 
       test('[string] fails with a type error', () {
@@ -348,7 +349,7 @@ void main() {
   });
 
   group('with positional parameters', () {
-    var parameters;
+    late json_rpc.Parameters parameters;
     setUp(() => parameters = json_rpc.Parameters('foo', [1, 2, 3, 4, 5]));
 
     test('value returns the wrapped value', () {

--- a/test/server/server_test.dart
+++ b/test/server/server_test.dart
@@ -11,7 +11,8 @@ import 'package:json_rpc_2/json_rpc_2.dart' as json_rpc;
 import 'utils.dart';
 
 void main() {
-  var controller;
+  late ServerController controller;
+
   setUp(() => controller = ServerController());
 
   test('calls a registered method with the given name', () {

--- a/test/server/stream_test.dart
+++ b/test/server/stream_test.dart
@@ -10,9 +10,10 @@ import 'package:test/test.dart';
 import 'package:json_rpc_2/json_rpc_2.dart' as json_rpc;
 
 void main() {
-  var requestController;
-  var responseController;
-  var server;
+  late StreamController requestController;
+  late StreamController responseController;
+  late json_rpc.Server server;
+
   setUp(() {
     requestController = StreamController();
     responseController = StreamController();

--- a/test/server/utils.dart
+++ b/test/server/utils.dart
@@ -50,7 +50,7 @@ class ServerController {
 void expectErrorResponse(
     ServerController controller, request, int errorCode, String message,
     {data}) {
-  var id;
+  dynamic id;
   if (request is Map) id = request['id'];
   data ??= {'request': request};
 


### PR DESCRIPTION
Prep for publishing 3.0.2:

- switch to using `package:lints` (and address analysis issues found)
- update markdown badges in the readme

This PR did change some types in the `lib/` directory from implicit dynamic, so we'll want to make sure that the behavior of the library didn't change.
