### PR TITLE
Use a public final field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.3-dev
+
 ## 3.0.2
 
 * Switch to using `package:lints`.

--- a/lib/src/parameters.dart
+++ b/lib/src/parameters.dart
@@ -26,10 +26,9 @@ class Parameters {
   ///
   /// If this is accessed for a [Parameter] that was not passed, the request
   /// will be automatically rejected. To avoid this, use [Parameter.valueOr].
-  dynamic get value => _value;
-  final dynamic _value;
+  final dynamic value;
 
-  Parameters(this.method, this._value);
+  Parameters(this.method, this.value);
 
   /// Returns a single parameter.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_rpc_2
-version: 3.0.2
+version: 3.0.3-dev
 description: >-
   Utilities to write a client or server using the JSON-RPC 2.0 spec.
 repository: https://github.com/dart-lang/json_rpc_2


### PR DESCRIPTION
There is no setter, so no need for a private field and public forwarding
getter.