### PR TITLE
Added the ability to pass in a custom Json RPC ID

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -113,12 +113,12 @@ class Client {
   ///
   /// Throws a [StateError] if the client is closed while the request is in
   /// flight, or if the client is closed when this method is called.
-  Future sendRequest(String method, [parameters]) {
-    var id = _id++;
-    _send(method, parameters, id);
+  Future sendRequest(String method, [parameters, int? id]) {
+    var idAct = id ?? _id++;
+    _send(method, parameters, idAct);
 
     var completer = Completer.sync();
-    _pendingRequests[id] = _Request(method, completer, Chain.current());
+    _pendingRequests[idAct] = _Request(method, completer, Chain.current());
     return completer.future;
   }
 

--- a/lib/src/peer.dart
+++ b/lib/src/peer.dart
@@ -95,7 +95,7 @@ class Peer implements Client, Server {
 
   @override
   Future sendRequest(String method, [parameters, int? id]) =>
-      _client.sendRequest(method, parameters);
+      _client.sendRequest(method, parameters, id);
 
   @override
   void sendNotification(String method, [parameters]) =>

--- a/lib/src/peer.dart
+++ b/lib/src/peer.dart
@@ -94,7 +94,7 @@ class Peer implements Client, Server {
   // Client methods.
 
   @override
-  Future sendRequest(String method, [parameters]) =>
+  Future sendRequest(String method, [parameters, int? id]) =>
       _client.sendRequest(method, parameters);
 
   @override


### PR DESCRIPTION
I needed the ability to pass in a custom RPC id.

It was easy to add, and doesn't affect the protocol's API in any way, just added functionality.